### PR TITLE
Added buffer security checks in sentence.cpp

### DIFF
--- a/mp/src/public/sentence.cpp
+++ b/mp/src/public/sentence.cpp
@@ -454,7 +454,7 @@ void CSentence::ParsePlaintext( CUtlBuffer& buf )
 	text[ 0 ] = 0;
 	while ( 1 )
 	{
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( !stricmp( token, "}" ) )
 			break;
 
@@ -473,19 +473,19 @@ void CSentence::ParseWords( CUtlBuffer& buf )
 
 	while ( 1 )
 	{
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( !stricmp( token, "}" ) )
 			break;
 
 		if ( stricmp( token, "WORD" ) )
 			break;
 
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		Q_strncpy( word, token, sizeof( word ) );
 
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		start = atof( token );
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		end = atof( token );
 
 		CWordTag *wt = new CWordTag( word );
@@ -495,13 +495,13 @@ void CSentence::ParseWords( CUtlBuffer& buf )
 
 		AddWordTag( wt );
 
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( stricmp( token, "{" ) )
 			break;
 
 		while ( 1 )
 		{
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			if ( !stricmp( token, "}" ) )
 				break;
 
@@ -513,13 +513,13 @@ void CSentence::ParseWords( CUtlBuffer& buf )
 
 			code = atoi( token );
 
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			Q_strncpy( phonemename, token, sizeof( phonemename ) );
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			start = atof( token );
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			end = atof( token );
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			volume = atof( token );
 
 			CPhonemeTag *pt = new CPhonemeTag();
@@ -539,13 +539,13 @@ void CSentence::ParseEmphasis( CUtlBuffer& buf )
 	char token[ 4096 ];
 	while ( 1 )
 	{
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( !stricmp( token, "}" ) )
 			break;
 
 		char t[ 256 ];
 		Q_strncpy( t, token, sizeof( t ) );
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 
 		char value[ 256 ];
 		Q_strncpy( value, token, sizeof( value ) );
@@ -573,15 +573,15 @@ void CSentence::ParseCloseCaption( CUtlBuffer& buf )
 		//   PHRASE char streamlength "streambytes" starttime endtime
 		//   PHRASE unicode streamlength "streambytes" starttime endtime
 		// }
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( !stricmp( token, "}" ) )
 			break;
 
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( stricmp( token, "{" ) )
 			break;
 
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		while ( 1 )
 		{
 			if ( !stricmp( token, "}" ) )
@@ -596,7 +596,7 @@ void CSentence::ParseCloseCaption( CUtlBuffer& buf )
 
 			memset( cc_stream, 0, sizeof( cc_stream ) );
 
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			Q_strncpy( cc_type, token, sizeof( cc_type ) );
 
 			bool unicode = false;
@@ -609,7 +609,7 @@ void CSentence::ParseCloseCaption( CUtlBuffer& buf )
 				Assert( 0 );
 			}
 
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 			cc_length = atoi( token );
 			Assert( cc_length >= 0 && cc_length < sizeof( cc_stream ) );
 			// Skip space
@@ -619,10 +619,10 @@ void CSentence::ParseCloseCaption( CUtlBuffer& buf )
 			
 			// Skip space
 			buf.GetChar();
-			buf.GetString( token );
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
+			buf.GetString( token, sizeof(token) );
 
-			buf.GetString( token );
+			buf.GetString( token, sizeof(token) );
 		}
 	}
 }
@@ -632,7 +632,7 @@ void CSentence::ParseOptions( CUtlBuffer& buf )
 	char token[ 4096 ];
 	while ( 1 )
 	{
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( !stricmp( token, "}" ) )
 			break;
 
@@ -642,7 +642,7 @@ void CSentence::ParseOptions( CUtlBuffer& buf )
 		char key[ 256 ];
 		Q_strncpy( key, token, sizeof( key ) );
 		char value[ 256 ];
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		Q_strncpy( value, token, sizeof( value ) );
 
 		if ( !strcmpi( key, "voice_duck" ) )
@@ -668,14 +668,14 @@ void CSentence::ParseDataVersionOnePointZero( CUtlBuffer& buf )
 
 	while ( 1 )
 	{
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( strlen( token ) <= 0 )
 			break;
 
 		char section[ 256 ];
 		Q_strncpy( section, token, sizeof( section ) );
 
-		buf.GetString( token );
+		buf.GetString( token, sizeof(token) );
 		if ( stricmp( token, "{" ) )
 			break;
 
@@ -1042,12 +1042,12 @@ void CSentence::InitFromBuffer( CUtlBuffer& buf )
 	Reset();
 
 	char token[ 4096 ];
-	buf.GetString( token );
+	buf.GetString( token, sizeof(token) );
 
 	if ( stricmp( token, "VERSION" ) )
 		return;
 
-	buf.GetString( token );
+	buf.GetString( token, sizeof(token) );
 	if ( atof( token ) == 1.0f )
 	{
 		ParseDataVersionOnePointZero( buf );


### PR DESCRIPTION
This fixes a buffer overflow using malicious sound files. This exploit is currently commonly being used during the current attacks on Source engine games and allows for arbitrary code execution.

Affected mods include but are not limited to:

Fistfull of frags
Team Fortress 2 Classic
Fortress Forever
No more room in hell
Vikings and Knights 2
Counterstrike: Source
IMPORTANT: This is by far not the only vulnerability available to these mods. Most vulnerabilities are contained in the Source SDK 2013 Base and are not available in code form. In live games such as TF2 and CS:GO, many of these have been patched. I recommend that these changes are ported immediately.

--PistonMiner
